### PR TITLE
Add and style About Me section to homepage

### DIFF
--- a/amazon-stylesheet.css
+++ b/amazon-stylesheet.css
@@ -326,6 +326,7 @@
     /* background-image: url("CleaningTool_1x._SY116_CB563137408_.jpg"); */
     background-size: cover;
     background-repeat:no-repeat;
+    background-color: #ffffff;
 }
 .paragraph_inside_boxcontainer{
     margin-top:10px;


### PR DESCRIPTION
##  Description

This PR fixes the issue where the background of product image containers appeared darker than expected, despite .box_container having a white background.
The discrepancy was caused because the inner div .img_inboxcontainer_single did not explicitly define a background color.
A white background (#ffffff) has now been applied to .img_inboxcontainer_single in amazon-stylesheet.css to align the visuals with the intended design.

## Screenshot

![image](https://github.com/user-attachments/assets/3b774bba-b252-4f9d-9387-84abde851c39)

Closes #1